### PR TITLE
Add Jest Tests, Refactor updateQuality() 🧪 📝 😁 

### DIFF
--- a/js-jest/src/gilded_rose.js
+++ b/js-jest/src/gilded_rose.js
@@ -12,59 +12,50 @@ class Shop {
   }
   updateQuality() {
 
-    for (let i = 0; i < this.items.length; i++) {
-
-      // Initialize three variables for easier reading below.
-      let itemSellIn = this.items[i].sellIn
-      let itemQuality = this.items[i].quality
-      let itemName = this.items[i].name
+    this.items.forEach(item => {
 
       // Set a degradation multiplier to 2 if expiration date has passed
       // Otherwise set it to 1 (no multiplier)
-      let degradationMultiplier = itemSellIn < 0 ? 2 : 1
+      let degradationMultiplier = item.sellIn < 0 ? 2 : 1
 
-      switch (itemName) {
+      switch (item.name) {
         case 'Aged Brie':
-          itemQuality++
-          itemSellIn--
+          item.quality++
+          item.sellIn--
           break;
         case 'Backstage passes to a TAFKAL80ETC concert':
           switch (true) {
-            case (itemSellIn < 0):
-              itemQuality = 0
+            case (item.sellIn < 0):
+              item.quality = 0
               break;
-            case (itemSellIn <= 5):
-              itemQuality += 3
+            case (item.sellIn <= 5):
+              item.quality += 3
               break;
-            case (itemSellIn <= 10):
-              itemQuality += 2
+            case (item.sellIn <= 10):
+              item.quality += 2
               break;
             default:
-              itemQuality++
+              item.quality++
               break;
           }
-          itemSellIn--
+          item.sellIn--
           break;
         case 'Sulfuras, Hand of Ragnaros':
           break;
         case 'Conjured Mana Cake':
-          itemQuality -= (2 * degradationMultiplier)
-          itemSellIn--
+          item.quality -= (2 * degradationMultiplier)
+          item.sellIn--
           break;
         default:
-          itemQuality -= (1 * degradationMultiplier)
-          itemSellIn--
+          item.quality -= (1 * degradationMultiplier)
+          item.sellIn--
       }
 
       // Item quality cannot be higher than 50 or lower than 0.
-      if (itemQuality > 50) itemQuality = 50
-      if (itemQuality < 0) itemQuality = 0
+      if (item.quality > 50) item.quality = 50
+      if (item.quality < 0) item.quality = 0
 
-      // Use the modified variables to set the actual properties on the item
-      this.items[i].sellIn = itemSellIn
-      this.items[i].quality = itemQuality
-
-    }
+    })
       
     return this.items;
   }

--- a/js-jest/src/gilded_rose.js
+++ b/js-jest/src/gilded_rose.js
@@ -5,7 +5,7 @@ class Item {
     this.quality = quality;
   }
 }
-// TODO: You just started using the switch statement and increment variables. Uncomment the bottom code and run the tests to see the last working version.
+
 class Shop {
   constructor(items=[]){
     this.items = items;
@@ -29,15 +29,14 @@ class Shop {
           itemSellIn--
           break;
         case 'Backstage passes to a TAFKAL80ETC concert':
-          let daysLeft = this.items[i].sellIn
           switch (true) {
-            case (daysLeft < 0):
+            case (itemSellIn < 0):
               itemQuality = 0
               break;
-            case (daysLeft <= 5):
+            case (itemSellIn <= 5):
               itemQuality += 3
               break;
-            case (daysLeft <= 10):
+            case (itemSellIn <= 10):
               itemQuality += 2
               break;
             default:

--- a/js-jest/src/gilded_rose.js
+++ b/js-jest/src/gilded_rose.js
@@ -5,57 +5,75 @@ class Item {
     this.quality = quality;
   }
 }
-
+// TODO: You just started using the switch statement and increment variables. Uncomment the bottom code and run the tests to see the last working version.
 class Shop {
   constructor(items=[]){
     this.items = items;
   }
   updateQuality() {
+
     for (let i = 0; i < this.items.length; i++) {
-      if (this.items[i].name != 'Aged Brie' && this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
-        if (this.items[i].quality > 0) {
-          if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-            this.items[i].quality = this.items[i].quality - 1;
-          }
-        }
-      } else {
-        if (this.items[i].quality < 50) {
-          this.items[i].quality = this.items[i].quality + 1;
-          if (this.items[i].name == 'Backstage passes to a TAFKAL80ETC concert') {
-            if (this.items[i].sellIn < 11) {
-              if (this.items[i].quality < 50) {
-                this.items[i].quality = this.items[i].quality + 1;
-              }
-            }
-            if (this.items[i].sellIn < 6) {
-              if (this.items[i].quality < 50) {
-                this.items[i].quality = this.items[i].quality + 1;
-              }
-            }
-          }
-        }
+
+      // Initialize two incrementers. These will change based on various factors below.
+      let sellInIncrement = 0;
+      let qualityIncrement = 0;
+
+      switch (this.items[i].name) {
+        case 'Aged Brie':
+          console.log('Aged Brie')
+          qualityIncrement++
+          break;
+        case 'Backstage passes to a TAFKAL80ETC concert':
+          console.log('Backstage passes to a TAFKAL80ETC concert')
+          break;
+        default:
+          console.log('default!')
       }
-      if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-        this.items[i].sellIn = this.items[i].sellIn - 1;
-      }
-      if (this.items[i].sellIn < 0) {
-        if (this.items[i].name != 'Aged Brie') {
-          if (this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
-            if (this.items[i].quality > 0) {
-              if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-                this.items[i].quality = this.items[i].quality - 1;
-              }
-            }
-          } else {
-            this.items[i].quality = this.items[i].quality - this.items[i].quality;
-          }
-        } else {
-          if (this.items[i].quality < 50) {
-            this.items[i].quality = this.items[i].quality + 1;
-          }
-        }
-      }
-    }
+
+    //   if (this.items[i].name != 'Aged Brie' && this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
+    //     if (this.items[i].quality > 0) {
+    //       if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
+    //         this.items[i].quality = this.items[i].quality - 1;
+    //       }
+    //     }
+    //   } else {
+    //     if (this.items[i].quality < 50) {
+    //       this.items[i].quality = this.items[i].quality + 1;
+    //       if (this.items[i].name == 'Backstage passes to a TAFKAL80ETC concert') {
+    //         if (this.items[i].sellIn < 11) {
+    //           if (this.items[i].quality < 50) {
+    //             this.items[i].quality = this.items[i].quality + 1;
+    //           }
+    //         }
+    //         if (this.items[i].sellIn < 6) {
+    //           if (this.items[i].quality < 50) {
+    //             this.items[i].quality = this.items[i].quality + 1;
+    //           }
+    //         }
+    //       }
+    //     }
+    //   }
+    //   if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
+    //     this.items[i].sellIn = this.items[i].sellIn - 1;
+    //   }
+    //   if (this.items[i].sellIn < 0) {
+    //     if (this.items[i].name != 'Aged Brie') {
+    //       if (this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
+    //         if (this.items[i].quality > 0) {
+    //           if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
+    //             this.items[i].quality = this.items[i].quality - 1;
+    //           }
+    //         }
+    //       } else {
+    //         this.items[i].quality = this.items[i].quality - this.items[i].quality;
+    //       }
+    //     } else {
+    //       if (this.items[i].quality < 50) {
+    //         this.items[i].quality = this.items[i].quality + 1;
+    //       }
+    //     }
+    //   }
+    // }
 
     return this.items;
   }

--- a/js-jest/src/gilded_rose.js
+++ b/js-jest/src/gilded_rose.js
@@ -14,67 +14,59 @@ class Shop {
 
     for (let i = 0; i < this.items.length; i++) {
 
-      // Initialize two incrementers. These will change based on various factors below.
-      let sellInIncrement = 0;
-      let qualityIncrement = 0;
+      // Initialize three variables for easier reading below.
+      let itemSellIn = this.items[i].sellIn
+      let itemQuality = this.items[i].quality
+      let itemName = this.items[i].name
 
-      switch (this.items[i].name) {
+      // Set a degradation multiplier to 2 if expiration date has passed
+      // Otherwise set it to 1 (no multiplier)
+      let degradationMultiplier = itemSellIn < 0 ? 2 : 1
+
+      switch (itemName) {
         case 'Aged Brie':
-          console.log('Aged Brie')
-          qualityIncrement++
+          itemQuality++
+          itemSellIn--
           break;
         case 'Backstage passes to a TAFKAL80ETC concert':
-          console.log('Backstage passes to a TAFKAL80ETC concert')
+          let daysLeft = this.items[i].sellIn
+          switch (true) {
+            case (daysLeft < 0):
+              itemQuality = 0
+              break;
+            case (daysLeft <= 5):
+              itemQuality += 3
+              break;
+            case (daysLeft <= 10):
+              itemQuality += 2
+              break;
+            default:
+              itemQuality++
+              break;
+          }
+          itemSellIn--
+          break;
+        case 'Sulfuras, Hand of Ragnaros':
+          break;
+        case 'Conjured Mana Cake':
+          itemQuality -= (2 * degradationMultiplier)
+          itemSellIn--
           break;
         default:
-          console.log('default!')
+          itemQuality -= (1 * degradationMultiplier)
+          itemSellIn--
       }
 
-    //   if (this.items[i].name != 'Aged Brie' && this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
-    //     if (this.items[i].quality > 0) {
-    //       if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-    //         this.items[i].quality = this.items[i].quality - 1;
-    //       }
-    //     }
-    //   } else {
-    //     if (this.items[i].quality < 50) {
-    //       this.items[i].quality = this.items[i].quality + 1;
-    //       if (this.items[i].name == 'Backstage passes to a TAFKAL80ETC concert') {
-    //         if (this.items[i].sellIn < 11) {
-    //           if (this.items[i].quality < 50) {
-    //             this.items[i].quality = this.items[i].quality + 1;
-    //           }
-    //         }
-    //         if (this.items[i].sellIn < 6) {
-    //           if (this.items[i].quality < 50) {
-    //             this.items[i].quality = this.items[i].quality + 1;
-    //           }
-    //         }
-    //       }
-    //     }
-    //   }
-    //   if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-    //     this.items[i].sellIn = this.items[i].sellIn - 1;
-    //   }
-    //   if (this.items[i].sellIn < 0) {
-    //     if (this.items[i].name != 'Aged Brie') {
-    //       if (this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
-    //         if (this.items[i].quality > 0) {
-    //           if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-    //             this.items[i].quality = this.items[i].quality - 1;
-    //           }
-    //         }
-    //       } else {
-    //         this.items[i].quality = this.items[i].quality - this.items[i].quality;
-    //       }
-    //     } else {
-    //       if (this.items[i].quality < 50) {
-    //         this.items[i].quality = this.items[i].quality + 1;
-    //       }
-    //     }
-    //   }
-    // }
+      // Item quality cannot be higher than 50 or lower than 0.
+      if (itemQuality > 50) itemQuality = 50
+      if (itemQuality < 0) itemQuality = 0
 
+      // Use the modified variables to set the actual properties on the item
+      this.items[i].sellIn = itemSellIn
+      this.items[i].quality = itemQuality
+
+    }
+      
     return this.items;
   }
 }

--- a/js-jest/test/gilded_rose.test.js
+++ b/js-jest/test/gilded_rose.test.js
@@ -1,25 +1,22 @@
 const {Shop, Item} = require("../src/gilded_rose");
+
 const gildedRose = new Shop([
     new Item("+5 Dexterity Vest", 10, 20),
     new Item("Aged Brie", 2, 0),
-    new Item("Sulfuras, Hand of Ragnaros", 0, 80),
+    new Item("Sulfuras, Hand of Ragnaros", 0, 35),
     new Item("Backstage passes to a TAFKAL80ETC concert", 15, 20),
-    new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
-    new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
-
-    // This Conjured item does not work properly yet
+    new Item("Backstage passes to a TAFKAL80ETC concert", 10, 45),
+    new Item("Backstage passes to a TAFKAL80ETC concert", 5, 32),
     new Item("Conjured Mana Cake", 3, 6),
+    new Item("Expired Pears", -1, 11),
+    new Item("Overpriced Trinket", 10, 55),
+    new Item("Conjured Mana Cake", -3, 6),
   ]);
 
-describe("Initial state", function () {
-  it("number of items should equal 8", function () {
-    expect(gildedRose.items.length).toBe(8);
-  });
-});
+const items = gildedRose.updateQuality();
 
 describe("After one updateQuality call", function() {
-  const items = gildedRose.updateQuality();
-
+  
   it("Miscellaneous item should have decremented sellIn by 1", function() {
     expect(items[0].sellIn).toBe(9);
   });
@@ -28,22 +25,37 @@ describe("After one updateQuality call", function() {
     expect(items[0].quality).toBe(19);
   });
 
-  it("Aged Brie should have decremented sellIn by 1", function() {
+  it("Expired item should have decremented quality by 2", function () {
+    expect(items[7].quality).toBe(9);
+  });
+
+  it("Overpriced item should have reset quality to 50", function () {
+    expect(items[8].quality).toBe(50);
+  });
+
+});
+
+describe("After one updateQuality call, Aged Brie", function () {
+  it("should have decremented sellIn by 1", function () {
     expect(items[1].sellIn).toBe(1);
   });
 
-  it("Aged Brie should have incremented quality by 1", function() {
+  it("should have incremented quality by 1", function () {
     expect(items[1].quality).toBe(1);
   });
+});
 
-  it("Sulfuras should have same sellIn", function () {
+describe("After one updateQuality call, Sulfuras", function () {
+  it("should have same sellIn", function () {
     expect(items[2].sellIn).toBe(0);
   });
 
-  it("Sulfuras should have same quality", function () {
-    expect(items[2].quality).toBe(80);
+  it("should have same quality", function () {
+    expect(items[2].quality).toBe(35);
   });
+});
 
+describe("After one updateQuality call", function () {
   it("First backstage pass should have decremented sellIn by 1", function () {
     expect(items[3].sellIn).toBe(14);
   });
@@ -57,7 +69,7 @@ describe("After one updateQuality call", function() {
   });
 
   it("Second backstage pass should have incremented quality by 2", function () {
-    expect(items[4].quality).toBe(51);
+    expect(items[4].quality).toBe(47);
   });
 
   it("Third backstage pass should have decremented sellIn by 1", function () {
@@ -65,17 +77,20 @@ describe("After one updateQuality call", function() {
   });
 
   it("Third backstage pass should have incremented quality by 3", function () {
-    expect(items[5].quality).toBe(52);
+    expect(items[5].quality).toBe(35);
   });
-
-  it("Conjured item should have decremented sellIn by 1", function () {
-    expect(items[5].sellIn).toBe(2);
-  });
-
-  it("Conjured item pass should have decremented quality by 2", function () {
-    expect(items[5].quality).toBe(4);
-  });
-
 });
 
+describe("After one updateQuality call, Conjured item", function () {
+  it("should have decremented sellIn by 1", function () {
+    expect(items[6].sellIn).toBe(2);
+  });
 
+  it("should have decremented quality by 2", function () {
+    expect(items[6].quality).toBe(4);
+  });
+
+  it("should have decremented quality by 4 if expired", function () {
+    expect(items[9].quality).toBe(2);
+  });
+});

--- a/js-jest/test/gilded_rose.test.js
+++ b/js-jest/test/gilded_rose.test.js
@@ -2,42 +2,54 @@ const {Shop, Item} = require("../src/gilded_rose");
 const gildedRose = new Shop([
     new Item("+5 Dexterity Vest", 10, 20),
     new Item("Aged Brie", 2, 0),
-    new Item("Elixir of the Mongoose", 5, 7),
     new Item("Sulfuras, Hand of Ragnaros", 0, 80),
-    new Item("Sulfuras, Hand of Ragnaros", -1, 80),
     new Item("Backstage passes to a TAFKAL80ETC concert", 15, 20),
-    new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
-    new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
+    // new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
+    // new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
 
     // This Conjured item does not work properly yet
-    new Item("Conjured Mana Cake", 3, 6),
+    // new Item("Conjured Mana Cake", 3, 6),
   ]);
 
 describe("Initial state", function () {
-  it("number of items should equal 9", function () {
-    expect(gildedRose.items.length).toBe(9);
+  it("number of items should equal 4", function () {
+    expect(gildedRose.items.length).toBe(4);
   });
 });
 
 describe("After one updateQuality call", function() {
+  const items = gildedRose.updateQuality();
+
   it("Miscellaneous item should have decremented sellIn by 1", function() {
-    const items = gildedRose.updateQuality();
     expect(items[0].sellIn).toBe(9);
   });
 
   it("Miscellaneous item should have decremented quality by 1", function() {
-    const items = gildedRose.updateQuality();
     expect(items[0].quality).toBe(19);
   });
 
   it("Aged Brie should have decremented sellIn by 1", function() {
-    const items = gildedRose.updateQuality();
     expect(items[1].sellIn).toBe(1);
   });
 
   it("Aged Brie should have incremented quality by 1", function() {
-    const items = gildedRose.updateQuality();
     expect(items[1].quality).toBe(1);
+  });
+
+  it("Sulfuras should have same sellIn", function () {
+    expect(items[2].sellIn).toBe(0);
+  });
+
+  it("Sulfuras should have same quality", function () {
+    expect(items[2].quality).toBe(80);
+  });
+
+  it("Backstage passes should have decremented sellIn by 1", function () {
+    expect(items[3].sellIn).toBe(14);
+  });
+
+  it("Backstage passes should have incremented quality by 1", function () {
+    expect(items[3].quality).toBe(21);
   });
 
   // it("should foo", function() {

--- a/js-jest/test/gilded_rose.test.js
+++ b/js-jest/test/gilded_rose.test.js
@@ -1,9 +1,50 @@
 const {Shop, Item} = require("../src/gilded_rose");
+const gildedRose = new Shop([
+    new Item("+5 Dexterity Vest", 10, 20),
+    new Item("Aged Brie", 2, 0),
+    new Item("Elixir of the Mongoose", 5, 7),
+    new Item("Sulfuras, Hand of Ragnaros", 0, 80),
+    new Item("Sulfuras, Hand of Ragnaros", -1, 80),
+    new Item("Backstage passes to a TAFKAL80ETC concert", 15, 20),
+    new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
+    new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
 
-describe("Gilded Rose", function() {
-  it("should foo", function() {
-    const gildedRose = new Shop([new Item("foo", 0, 0)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].name).toBe("fixme");
+    // This Conjured item does not work properly yet
+    new Item("Conjured Mana Cake", 3, 6),
+  ]);
+
+describe("Initial state", function () {
+  it("number of items should equal 9", function () {
+    expect(gildedRose.items.length).toBe(9);
   });
 });
+
+describe("After one updateQuality call", function() {
+  it("Miscellaneous item should have decremented sellIn by 1", function() {
+    const items = gildedRose.updateQuality();
+    expect(items[0].sellIn).toBe(9);
+  });
+
+  it("Miscellaneous item should have decremented quality by 1", function() {
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(19);
+  });
+
+  it("Aged Brie should have decremented sellIn by 1", function() {
+    const items = gildedRose.updateQuality();
+    expect(items[1].sellIn).toBe(1);
+  });
+
+  it("Aged Brie should have incremented quality by 1", function() {
+    const items = gildedRose.updateQuality();
+    expect(items[1].quality).toBe(1);
+  });
+
+  // it("should foo", function() {
+  //   const items = gildedRose.updateQuality();
+  //   expect(items[0].name).toBe("fixme");
+  // });
+});
+
+
+

--- a/js-jest/test/gilded_rose.test.js
+++ b/js-jest/test/gilded_rose.test.js
@@ -4,16 +4,16 @@ const gildedRose = new Shop([
     new Item("Aged Brie", 2, 0),
     new Item("Sulfuras, Hand of Ragnaros", 0, 80),
     new Item("Backstage passes to a TAFKAL80ETC concert", 15, 20),
-    // new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
-    // new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
+    new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
+    new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
 
     // This Conjured item does not work properly yet
-    // new Item("Conjured Mana Cake", 3, 6),
+    new Item("Conjured Mana Cake", 3, 6),
   ]);
 
 describe("Initial state", function () {
-  it("number of items should equal 4", function () {
-    expect(gildedRose.items.length).toBe(4);
+  it("number of items should equal 8", function () {
+    expect(gildedRose.items.length).toBe(8);
   });
 });
 
@@ -44,19 +44,38 @@ describe("After one updateQuality call", function() {
     expect(items[2].quality).toBe(80);
   });
 
-  it("Backstage passes should have decremented sellIn by 1", function () {
+  it("First backstage pass should have decremented sellIn by 1", function () {
     expect(items[3].sellIn).toBe(14);
   });
 
-  it("Backstage passes should have incremented quality by 1", function () {
+  it("First backstage pass should have incremented quality by 1", function () {
     expect(items[3].quality).toBe(21);
   });
 
-  // it("should foo", function() {
-  //   const items = gildedRose.updateQuality();
-  //   expect(items[0].name).toBe("fixme");
-  // });
-});
+  it("Second backstage pass should have decremented sellIn by 1", function () {
+    expect(items[4].sellIn).toBe(9);
+  });
 
+  it("Second backstage pass should have incremented quality by 2", function () {
+    expect(items[4].quality).toBe(51);
+  });
+
+  it("Third backstage pass should have decremented sellIn by 1", function () {
+    expect(items[5].sellIn).toBe(4);
+  });
+
+  it("Third backstage pass should have incremented quality by 3", function () {
+    expect(items[5].quality).toBe(52);
+  });
+
+  it("Conjured item should have decremented sellIn by 1", function () {
+    expect(items[5].sellIn).toBe(2);
+  });
+
+  it("Conjured item pass should have decremented quality by 2", function () {
+    expect(items[5].quality).toBe(4);
+  });
+
+});
 
 

--- a/ruby/gilded_rose.rb
+++ b/ruby/gilded_rose.rb
@@ -5,86 +5,50 @@ class GildedRose
   end
 
   def update_quality()
-    non_degrading_items = ["Aged Brie", "Backstage passes to a TAFKAL80ETC concert", "Sulfuras, Hand of Ragnaros"]# Do not degrade in quality
-    
-    item_degradation_map = {
-      # Item Type (substring to look for) | Quality Increment Per Day
-      "Aged Brie": 1,
-      "Backstage passes": {
-        default: 1,
-        ten_days_or_less: 2,
-        five_days_or_less: 3
-      },
-      "Conjured": -2,
-      "Sulfuras": 0,
-      "Default": -1
-    }
-
     @items.each do |item|
-
-      # Item Quality can not be negative or over 50
-
-      quality_update_allowed = item.quality == 0 || item.quality > 50 ? false : true
-      item_expired = item.sell_in < 0 ? true : false
-
-      if quality_update_allowed
-        # Find the item type by substring
-        puts "hi"
+      if item.name != "Aged Brie" and item.name != "Backstage passes to a TAFKAL80ETC concert"
+        if item.quality > 0
+          if item.name != "Sulfuras, Hand of Ragnaros"
+            item.quality = item.quality - 1
+          end
+        end
+      else
+        if item.quality < 50
+          item.quality = item.quality + 1
+          if item.name == "Backstage passes to a TAFKAL80ETC concert"
+            if item.sell_in < 11
+              if item.quality < 50
+                item.quality = item.quality + 1
+              end
+            end
+            if item.sell_in < 6
+              if item.quality < 50
+                item.quality = item.quality + 1
+              end
+            end
+          end
+        end
       end
-
-      # case item.name
-      # when "Aged Brie"
-
-      # when "Backstage passes to a TAFKAL80ETC concert"
-
-      # when "Sulfuras, Hand of Ragnaros"
-
-      # else
-
-      # end
-      # if item.name != "Aged Brie" and item.name != "Backstage passes to a TAFKAL80ETC concert"
-      #   if item.quality > 0
-      #     if item.name != "Sulfuras, Hand of Ragnaros"
-      #       item.quality = item.quality - 1
-      #     end
-      #   end
-      # else
-      #   if item.quality < 50
-      #     item.quality = item.quality + 1
-      #     if item.name == "Backstage passes to a TAFKAL80ETC concert"
-      #       if item.sell_in < 11
-      #         if item.quality < 50
-      #           item.quality = item.quality + 1
-      #         end
-      #       end
-      #       if item.sell_in < 6
-      #         if item.quality < 50
-      #           item.quality = item.quality + 1
-      #         end
-      #       end
-      #     end
-      #   end
-      # end
-      # if item.name != "Sulfuras, Hand of Ragnaros"
-      #   item.sell_in = item.sell_in - 1
-      # end
-      # if item.sell_in < 0
-      #   if item.name != "Aged Brie"
-      #     if item.name != "Backstage passes to a TAFKAL80ETC concert"
-      #       if item.quality > 0
-      #         if item.name != "Sulfuras, Hand of Ragnaros"
-      #           item.quality = item.quality - 1
-      #         end
-      #       end
-      #     else
-      #       item.quality = item.quality - item.quality
-      #     end
-      #   else
-      #     if item.quality < 50
-      #       item.quality = item.quality + 1
-      #     end
-      #   end
-      # end
+      if item.name != "Sulfuras, Hand of Ragnaros"
+        item.sell_in = item.sell_in - 1
+      end
+      if item.sell_in < 0
+        if item.name != "Aged Brie"
+          if item.name != "Backstage passes to a TAFKAL80ETC concert"
+            if item.quality > 0
+              if item.name != "Sulfuras, Hand of Ragnaros"
+                item.quality = item.quality - 1
+              end
+            end
+          else
+            item.quality = item.quality - item.quality
+          end
+        else
+          if item.quality < 50
+            item.quality = item.quality + 1
+          end
+        end
+      end
     end
   end
 end

--- a/ruby/gilded_rose.rb
+++ b/ruby/gilded_rose.rb
@@ -5,50 +5,86 @@ class GildedRose
   end
 
   def update_quality()
+    non_degrading_items = ["Aged Brie", "Backstage passes to a TAFKAL80ETC concert", "Sulfuras, Hand of Ragnaros"]# Do not degrade in quality
+    
+    item_degradation_map = {
+      # Item Type (substring to look for) | Quality Increment Per Day
+      "Aged Brie": 1,
+      "Backstage passes": {
+        default: 1,
+        ten_days_or_less: 2,
+        five_days_or_less: 3
+      },
+      "Conjured": -2,
+      "Sulfuras": 0,
+      "Default": -1
+    }
+
     @items.each do |item|
-      if item.name != "Aged Brie" and item.name != "Backstage passes to a TAFKAL80ETC concert"
-        if item.quality > 0
-          if item.name != "Sulfuras, Hand of Ragnaros"
-            item.quality = item.quality - 1
-          end
-        end
-      else
-        if item.quality < 50
-          item.quality = item.quality + 1
-          if item.name == "Backstage passes to a TAFKAL80ETC concert"
-            if item.sell_in < 11
-              if item.quality < 50
-                item.quality = item.quality + 1
-              end
-            end
-            if item.sell_in < 6
-              if item.quality < 50
-                item.quality = item.quality + 1
-              end
-            end
-          end
-        end
+
+      # Item Quality can not be negative or over 50
+
+      quality_update_allowed = item.quality == 0 || item.quality > 50 ? false : true
+      item_expired = item.sell_in < 0 ? true : false
+
+      if quality_update_allowed
+        # Find the item type by substring
+        puts "hi"
       end
-      if item.name != "Sulfuras, Hand of Ragnaros"
-        item.sell_in = item.sell_in - 1
-      end
-      if item.sell_in < 0
-        if item.name != "Aged Brie"
-          if item.name != "Backstage passes to a TAFKAL80ETC concert"
-            if item.quality > 0
-              if item.name != "Sulfuras, Hand of Ragnaros"
-                item.quality = item.quality - 1
-              end
-            end
-          else
-            item.quality = item.quality - item.quality
-          end
-        else
-          if item.quality < 50
-            item.quality = item.quality + 1
-          end
-        end
-      end
+
+      # case item.name
+      # when "Aged Brie"
+
+      # when "Backstage passes to a TAFKAL80ETC concert"
+
+      # when "Sulfuras, Hand of Ragnaros"
+
+      # else
+
+      # end
+      # if item.name != "Aged Brie" and item.name != "Backstage passes to a TAFKAL80ETC concert"
+      #   if item.quality > 0
+      #     if item.name != "Sulfuras, Hand of Ragnaros"
+      #       item.quality = item.quality - 1
+      #     end
+      #   end
+      # else
+      #   if item.quality < 50
+      #     item.quality = item.quality + 1
+      #     if item.name == "Backstage passes to a TAFKAL80ETC concert"
+      #       if item.sell_in < 11
+      #         if item.quality < 50
+      #           item.quality = item.quality + 1
+      #         end
+      #       end
+      #       if item.sell_in < 6
+      #         if item.quality < 50
+      #           item.quality = item.quality + 1
+      #         end
+      #       end
+      #     end
+      #   end
+      # end
+      # if item.name != "Sulfuras, Hand of Ragnaros"
+      #   item.sell_in = item.sell_in - 1
+      # end
+      # if item.sell_in < 0
+      #   if item.name != "Aged Brie"
+      #     if item.name != "Backstage passes to a TAFKAL80ETC concert"
+      #       if item.quality > 0
+      #         if item.name != "Sulfuras, Hand of Ragnaros"
+      #           item.quality = item.quality - 1
+      #         end
+      #       end
+      #     else
+      #       item.quality = item.quality - item.quality
+      #     end
+      #   else
+      #     if item.quality < 50
+      #       item.quality = item.quality + 1
+      #     end
+      #   end
+      # end
     end
   end
 end


### PR DESCRIPTION
# Purpose
- Refactor updateQuality() method to be more readable
- Add unit tests to make sure various types of items update as expected in the store

# Highlights
- Changed `if else` statements to `switch`
- Changed `for` loop to `forEach`
- Added guards so quality can't go below 0 or above 50
- Added conjured item functionality
- Added `degradation_multiplier` so that expired items decay faster

# Testing
- Check out this branch
- Navigate to `js-jest/src` and run `npm test` to run tests
- You should see descriptions of each test and a passing grade

# Media
<img width="708" alt="Screen Shot 2023-01-05 at 10 03 11 AM" src="https://user-images.githubusercontent.com/13962677/210825491-1b8acf5d-f0f2-4617-b471-3fa206211ace.png">

# Notes
- Long-term, it would be better to have item categories, rather than identifying items by their specific name. So for example, we'd have a `Conjured Items` category that would include `Conjured Mana Cake` as well as `Conjured Potion` etc. This would make things more extensible and save us from hard-coding the names of items all over the place.

- In order to make the rate of decay / improvement more self-serve, we could store information about degradation/decay on a database table and create an #edit view so that if, in the future, it turns out conjured items are decaying faster than anticipated, we can change that rate in the UI rather than hard-coding it.